### PR TITLE
V1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release Notes
 
 ## v1.4.4 (2024-10-31)
-- 🐛 Bug fix. If you restore tabs from an empty group, it would error out
 - ✨ Restore tabs button is now disabled if the group is empty
+- 🐛 Bug fix. If you restore tabs from an empty group, it would error out
 
 ## v1.4.3 (2024-10-05)
 - 🐛 Bug fix where you couldn't delete a group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v1.4.4 (2024-10-31)
 - ✨ Restore tabs button is now disabled if the group is empty
-- 🐛 Bug fix. If you restore tabs from an empty group, it would error out
+- 🐛 Bug fix [#7](https://github.com/tab-guardian/tab-guardian/issues/7). If you restore tabs from an empty group, it would error out
+- 🐛 Bug fix [#8](https://github.com/tab-guardian/tab-guardian/issues/8). Reproduce by filtering groups, entering one, go back to main screen and you see only those groups that were visible when filtering. Other groups would not be visible
 
 ## v1.4.3 (2024-10-05)
 - 🐛 Bug fix where you couldn't delete a group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Release Notes
 
+## v1.4.4 (2024-10-31)
+- 🐛 Bug fix. If you restore tabs from an empty group, it would error out
+- ✨ Restore tabs button is now disabled if the group is empty
+
 ## v1.4.3 (2024-10-05)
-- 🐛 Fixed bug where you couldn't delete a group
+- 🐛 Bug fix where you couldn't delete a group
 
 ## v1.4.2 (2024-09-19)
 - 🐛 Additional group search fix following changes in the previous patch

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
     "name": "Tab Guardian",
     "description": "Browser extension that allows you to save and restore your tabs including encrypting them with a password",
     "permissions": ["storage", "tabs"],
-    "version": "1.4.3",
+    "version": "1.4.4",
     "web_accessible_resources": [
         {
             "resources": ["icons/*", "assets/*"],

--- a/src/popup/components/Views/GroupView/GroupControls/Actions/OpenAndDeleteAction.vue
+++ b/src/popup/components/Views/GroupView/GroupControls/Actions/OpenAndDeleteAction.vue
@@ -6,15 +6,17 @@ import { useTransStore } from '@/stores/trans'
 import upRemoveImage from '@/assets/images/tab-icons/up-remove.png'
 import Control from '@/components/Control.vue'
 
-const props = defineProps<{
-    group: Group
-}>()
+const props = defineProps<{ group: Group }>()
 
 const router = useRouter()
 const tabsStore = useTabsStore()
 const { trans } = useTransStore()
 
 async function openAndDeleteTabs(): Promise<void> {
+    if (props.group.links.length === 0) {
+        return
+    }
+
     await tabsStore.openAndDeleteTabs(props.group)
     router.push({ name: 'main' })
 }
@@ -25,6 +27,9 @@ async function openAndDeleteTabs(): Promise<void> {
         v-tippy="trans('Open tabs and delete this group')"
         @click="openAndDeleteTabs"
         class="bg-orange-300 dark:bg-orange-700"
+        :class="{
+            'cursor-not-allowed !opacity-40': group.links.length === 0,
+        }"
     >
         <img :src="upRemoveImage" alt="Open and delete tabs" class="dark:invert" />
     </Control>

--- a/src/popup/components/Views/GroupView/GroupControls/Actions/OpenTabsAction.vue
+++ b/src/popup/components/Views/GroupView/GroupControls/Actions/OpenTabsAction.vue
@@ -5,9 +5,7 @@ import upImage from '@/assets/images/tab-icons/up.png'
 import { useTabsStore } from '@/stores/tabs'
 import { useTransStore } from '@/stores/trans'
 
-defineProps<{
-    group: Group
-}>()
+defineProps<{ group: Group }>()
 
 const tabsStore = useTabsStore()
 const { trans } = useTransStore()
@@ -18,6 +16,9 @@ const { trans } = useTransStore()
         v-tippy="trans('Open tabs')"
         @click="tabsStore.openTabs(group)"
         class="bg-green-300 dark:bg-green-700"
+        :class="{
+            'cursor-not-allowed !opacity-40': group.links.length === 0,
+        }"
     >
         <img :src="upImage" alt="Open tabs" class="dark:invert" />
     </Control>

--- a/src/popup/components/Views/MainView/Groups/OpenTabsButton.vue
+++ b/src/popup/components/Views/MainView/Groups/OpenTabsButton.vue
@@ -6,9 +6,7 @@ import { useGroupStore } from '@/stores/group'
 import { useRouter } from 'vue-router'
 import upImage from '@/assets/images/tab-icons/up.png'
 
-const props = defineProps<{
-    group: Group
-}>()
+const props = defineProps<{ group: Group }>()
 
 const router = useRouter()
 const tabsStore = useTabsStore()
@@ -16,6 +14,10 @@ const groupStore = useGroupStore()
 const { trans } = useTransStore()
 
 async function openTabs(): Promise<void> {
+    if (props.group.links.length === 0) {
+        return
+    }
+
     if (!props.group.isPrivate) {
         await tabsStore.openTabs(props.group)
         return
@@ -44,5 +46,8 @@ async function openTabs(): Promise<void> {
         @click.prevent="openTabs"
         v-tippy="trans('Open tabs')"
         class="w-4 h-4 transition-transform hover:scale-110 dark:invert"
+        :class="{
+            'cursor-not-allowed opacity-40': group.links.length === 0,
+        }"
     />
 </template>

--- a/src/popup/components/Views/MainView/NewGroup/NewGroup.vue
+++ b/src/popup/components/Views/MainView/NewGroup/NewGroup.vue
@@ -20,6 +20,12 @@ onMounted(() => {
 
 onUnmounted(() => {
     document.removeEventListener('keydown', focusOnSearch)
+
+    if (initialGroups.value.length === 0) {
+        initialGroups.value = groupStore.groups
+    }
+
+    groupStore.groups = initialGroups.value
 })
 
 function focusOnSearch(e: KeyboardEvent): void {

--- a/src/popup/stores/tabs.ts
+++ b/src/popup/stores/tabs.ts
@@ -15,6 +15,10 @@ export const useTabsStore = defineStore('tabs', () => {
     const { trans } = useTransStore()
 
     async function openTabs(group: Group, userPass?: string): Promise<boolean> {
+        if (group.links.length === 0) {
+            return false
+        }
+
         if (!settingsStore.settings.encryptAfterRestore) {
             await restore(group)
             return true


### PR DESCRIPTION
- ✨ Restore tabs button is now disabled if the group is empty
- 🐛 Bug fix [#7](https://github.com/tab-guardian/tab-guardian/issues/7). If you restore tabs from an empty group, it would error out
- 🐛 Bug fix [#8](https://github.com/tab-guardian/tab-guardian/issues/8). Reproduce by filtering groups, entering one, go back to main screen and you see only those groups that were visible when filtering. Other groups would not be visible