### PR TITLE
Remove 'Group views' stats and related functionality from group details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v1.7.1 (2025-01-08)
+- 🧑‍💻 Remove 'Group views' stats from groups that was updated each time when we view the group
+
 ## v1.7.0 (2025-01-05)
 - ✨ When you filter groups, you can press `Enter` to open the first group in the list
 - 🐛 Bug fix. Sometimes, when you create a new group, it wasn't showing up immediately. The popup needed to be reloaded to see a new group. Now it fixed

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -15,8 +15,6 @@
     "bytes": {"message": "bytes"},
     "rebind": {"message": "Rebind"},
     "bound_to_url": {"message": "Bound to URL"},
-    "group_views": {"message": "Group views"},
-    "group_views_tip": {"message": "The number of times this group has been viewed"},
     "opened_tabs_times": {"message": "Opened tabs times"},
     "opened_tabs_times_tip": {"message": "The number of times the tabs in this group have been opened at once. Not the individual tabs opened"},
     "select": {"message": "Select"},

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -15,8 +15,6 @@
     "bytes": {"message": "байт"},
     "rebind": {"message": "Отвязать"},
     "bound_to_url": {"message": "Привязана к URL"},
-    "group_views": {"message": "Просмотров группы"},
-    "group_views_tip": {"message": "Количество просмотров этой группы"},
     "opened_tabs_times": {"message": "Открыто вкладок раз"},
     "opened_tabs_times_tip": {"message": "Общее количество одновременных открытий вкладок в этой группе. Не индивидуальное количество открытых вкладок"},
     "select": {"message": "Выбрать"},

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -15,8 +15,6 @@
     "bytes": {"message": "字节"},
     "rebind": {"message": "重新绑定"},
     "bound_to_url": {"message": "绑定到 URL"},
-    "group_views": {"message": "组浏览次数"},
-    "group_views_tip": {"message": "此组被查看的次数"},
     "opened_tabs_times": {"message": "打开标签页次数"},
     "opened_tabs_times_tip": {"message": "此组中的标签页被一次性打开的次数，而不是单个标签页的打开次数"},
     "select": {"message": "选择"},

--- a/src/popup/components/Views/GroupDetailsView/GroupDetailsView.vue
+++ b/src/popup/components/Views/GroupDetailsView/GroupDetailsView.vue
@@ -61,14 +61,6 @@ const group = computed<Group | null>(() => store.getGroupById(groupId))
                 />
 
                 <ListItem
-                    v-if="group.viewedTimes"
-                    :field="trans('group_views')"
-                    :value="group.viewedTimes.toString()"
-                >
-                    <Tip :tip="trans('group_views_tip')" />
-                </ListItem>
-
-                <ListItem
                     v-if="group.openedTimes"
                     :field="trans('opened_tabs_times')"
                     :value="group.openedTimes.toString()"

--- a/src/popup/components/Views/GroupView/GroupView.vue
+++ b/src/popup/components/Views/GroupView/GroupView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Group } from '@/types'
-import { computed, onMounted, watchEffect } from 'vue'
+import { computed, watchEffect } from 'vue'
 import { useGroupStore } from '@/stores/group'
 import trans from '@common/modules/trans'
 import { useRoute } from 'vue-router'
@@ -28,12 +28,6 @@ const group = computed<Group | null>(() => {
 
 const showButtons = computed<boolean>(() => {
     return group.value !== null && !group.value.isEncrypted
-})
-
-onMounted(() => {
-    if (group.value) {
-        store.incrementViewedTimes(group.value)
-    }
 })
 
 watchEffect(() => {

--- a/src/popup/stores/group.ts
+++ b/src/popup/stores/group.ts
@@ -181,7 +181,6 @@ export const useGroupStore = defineStore('group', () => {
             updatedAt: Date.now(),
             createdAt: Date.now(),
             openedTimes: 0,
-            viewedTimes: 0,
             links: [],
         }
 
@@ -320,24 +319,6 @@ export const useGroupStore = defineStore('group', () => {
         await saveGroup(group)
     }
 
-    async function incrementViewedTimes(group: Group): Promise<void> {
-        if (group.viewedTimes) {
-            group.viewedTimes++
-        } else {
-            group.viewedTimes = 1
-        }
-
-        groups.value = groups.value.map(g => {
-            if (g.id === group.id) {
-                g.viewedTimes = group.viewedTimes
-            }
-
-            return g
-        })
-
-        await saveGroup(group)
-    }
-
     async function deleteLink(groupId: number, linkId: number): Promise<void> {
         const group = getGroupById(groupId)
 
@@ -417,7 +398,6 @@ export const useGroupStore = defineStore('group', () => {
         deleteAllGroups,
         startGroupRenaming,
         incrementOpenedTimes,
-        incrementViewedTimes,
         loadGroupsFromStorage,
         setIcon,
         addGroups,

--- a/src/popup/types/index.ts
+++ b/src/popup/types/index.ts
@@ -14,7 +14,6 @@ export type Group = {
     isEncrypted: boolean
     updatedAt: number
     openedTimes?: number
-    viewedTimes?: number
     createdAt?: number
     hide?: boolean
     bindURL?: string


### PR DESCRIPTION
- 🧑‍💻 Remove 'Group views' stats from groups that was updated each time when we view the group